### PR TITLE
Possible solution for screen vs within classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,3 @@ repos:
     rev: '5.8.0'
     hooks:
     -   id: isort
-        name: isort
-        entry: poetry run isort
-        language: python
-        types: [file, python]

--- a/selenium_testing_library/locators.py
+++ b/selenium_testing_library/locators.py
@@ -4,6 +4,8 @@ from selenium.webdriver import Remote as Driver  # type: ignore
 from selenium.webdriver.common.by import By as SeleniumBy  # type: ignore
 from selenium.webdriver.remote.webelement import WebElement  # type: ignore
 
+from .screen import ElementsFinder
+
 
 class By:
     CLASS_NAME: str = SeleniumBy.CLASS_NAME
@@ -36,8 +38,8 @@ class Locator:
         yield self.BY
         yield self.selector
 
-    def find_elements(self, driver: Driver) -> List[WebElement]:
-        return driver.find_elements(*self)
+    def find_elements(self, finder: ElementsFinder) -> List[WebElement]:
+        return finder.find_elements(*self)
 
     def _exact_or_not(self, operator):
         if self.exact:
@@ -80,22 +82,22 @@ class ClassName(Locator):
 class Role(Locator):
     BY = By.ROLE
 
-    def find_elements(self, driver: Driver) -> List[WebElement]:
-        return driver.find_elements(*XPath(f"//*[{self._exact_or_not('@role')}]"))
+    def find_elements(self, finder: ElementsFinder) -> List[WebElement]:
+        return finder.find_elements(*XPath(f"//*[{self._exact_or_not('@role')}]"))
 
 
 class Text(Locator):
     BY = By.TEXT
 
-    def find_elements(self, driver: Driver) -> List[WebElement]:
-        return driver.find_elements(*XPath(f'//*[{self._exact_or_not("text()")}]'))
+    def find_elements(self, finder: ElementsFinder) -> List[WebElement]:
+        return finder.find_elements(*XPath(f'//*[{self._exact_or_not("text()")}]'))
 
 
 class PlaceholderText(Locator):
     BY = By.PLACEHOLDER_TEXT
 
-    def find_elements(self, driver: Driver) -> List[WebElement]:
-        return driver.find_elements(
+    def find_elements(self, finder: ElementsFinder) -> List[WebElement]:
+        return finder.find_elements(
             *XPath(f'//*[{self._exact_or_not("@placeholder")}]')
         )
 
@@ -103,19 +105,19 @@ class PlaceholderText(Locator):
 class LabelText(Locator):
     BY = By.LABEL_TEXT
 
-    def find_elements(self, driver):
-        labels: WebElement = driver.find_elements(
+    def find_elements(self, finder: ElementsFinder):
+        labels: WebElement = finder.find_elements(
             *XPath(f'//label[{self._exact_or_not("text()")}]')
         )
         elements = []
         for label in labels:
             for_ = label.get_attribute("for")
             if for_ is not None:
-                elements += driver.find_elements(*Id(for_))
+                elements += finder.find_elements(*Id(for_))
                 continue
             id_ = label.get_attribute("id")
             if id_:
-                elements += driver.find_elements(*Css(f"[aria-labelledby='{id_}']"))
+                elements += finder.find_elements(*Css(f"[aria-labelledby='{id_}']"))
                 continue
         return elements
 
@@ -123,22 +125,22 @@ class LabelText(Locator):
 class AltText(Locator):
     BY = By.ALT_TEXT
 
-    def find_elements(self, driver: Driver) -> List[WebElement]:
-        return driver.find_elements(*XPath(f'//*[{self._exact_or_not("@alt")}]'))
+    def find_elements(self, finder: ElementsFinder) -> List[WebElement]:
+        return finder.find_elements(*XPath(f'//*[{self._exact_or_not("@alt")}]'))
 
 
 class Title(Locator):
     BY = By.TITLE
 
-    def find_elements(self, driver: Driver) -> List[WebElement]:
-        return driver.find_elements(*XPath(f'//*[{self._exact_or_not("@title")}]'))
+    def find_elements(self, finder: ElementsFinder) -> List[WebElement]:
+        return finder.find_elements(*XPath(f'//*[{self._exact_or_not("@title")}]'))
 
 
 class TestId(Locator):
     BY = By.TITLE
 
-    def find_elements(self, driver: Driver) -> List[WebElement]:
-        return driver.find_elements(
+    def find_elements(self, finder: ElementsFinder) -> List[WebElement]:
+        return finder.find_elements(
             *XPath(f'//*[{self._exact_or_not("@data-testid")}]')
         )
 
@@ -146,8 +148,8 @@ class TestId(Locator):
 class DisplayValue(Locator):
     BY = By.DISPLAY_VALUE
 
-    def find_elements(self, driver: Driver) -> List[WebElement]:
-        els = driver.find_elements(
+    def find_elements(self, finder: ElementsFinder) -> List[WebElement]:
+        els = finder.find_elements(
             *XPath(f"//*[self::input or self::textarea or self::select]")
         )
         if self.exact:

--- a/selenium_testing_library/screen.py
+++ b/selenium_testing_library/screen.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import Callable, List, Optional, Protocol, TypeVar
+from typing import Callable, Generic, List, Optional, Protocol, TypeVar
 
 from selenium.common.exceptions import TimeoutException  # type: ignore
-from selenium.webdriver.remote.webdriver import (
-    WebDriver as RemoteWebDriver,  # type: ignore
-)
 from selenium.webdriver.remote.webelement import WebElement  # type: ignore
 from selenium.webdriver.support import expected_conditions as EC  # type: ignore
 from selenium.webdriver.support.ui import WebDriverWait  # type: ignore
@@ -49,8 +46,11 @@ class ElementsFinder(Protocol):
         ...
 
 
-class Screen:
-    def __init__(self, driver: RemoteWebDriver):
+DriverType = TypeVar("DriverType", bound=ElementsFinder)
+
+
+class Screen(Generic[DriverType]):
+    def __init__(self, driver: DriverType):
         self.driver = driver
         self._finder: ElementsFinder = driver
 
@@ -434,7 +434,7 @@ class Screen:
 
     def wait_for(
         self,
-        method: Callable[[RemoteWebDriver], T],
+        method: Callable[[DriverType], T],
         *,
         timeout=5,
         poll_frequency=0.5,


### PR DESCRIPTION
The problem is that Screen and Within classes both accept parameters that are very similar, but not exactly the same (WebDriver vs WebElement). All the methods in Screen/Within classes only really need `find_elements` which is present in both WebDriver and WebElement, but unfortunately I can't `ElementsFinder` cast as the type in the constructor because then the passthrough `screen.driver` and `within.element` will also only have `find_elements` available which is not what we want.